### PR TITLE
Adding Ratio of WJet data/mc checking functionality.

### DIFF
--- a/HistogramMgr.h
+++ b/HistogramMgr.h
@@ -270,7 +270,7 @@ cutlevel(x), doMuon(y)
   defineHist("TauPt",    "#tau p_{T}", "GeV", 20, 0 , 200 );
   defineHist("TauEta",   "#tau p_{T}", "GeV", 20, 0 , 200 );
   defineHist("MET",      "MET", "GeV", 20, 0 , 200 );
-  defineHist("LepTMass", "Lepton Transverse Mass", "GeV", 20, 0, 50 );
+  defineHist("LepTMass", "Lepton Transverse Mass", "GeV", 20, 0, 150 );
   defineHist("DeltaRLep", "#Delta R(#tau,l)", "", 62,0,6.2);
   defineHist("DeltaRJet", "#Delta R_{min}(#tau,jet)", "",62,0,6.2);
   defineHist("DeltaPhiTMET","#Delta #phi(#tau,MET)", "", 62,-3.2,3.2);

--- a/ZTT_XSection.cc
+++ b/ZTT_XSection.cc
@@ -67,6 +67,7 @@ int main(int argc, char** argv) {
 
 
   //add the histrograms of lepton and tau visible mass (both for opposite sign and same sign pair )
+  EventHisto beforeTMass("BeforeTMass",doMuon);
   EventHisto basicselection("BasicSelection",doMuon);
   ObjectHisto noCut      ("NoCut", doMuon);
   ObjectHisto passTrigger("PassTrigger", doMuon);
@@ -190,7 +191,12 @@ int main(int argc, char** argv) {
 	eventWeight *= 1.9;
       }
     }
+    //ttbar veto with bjet veto
+    if(GetBJets()) { continue; }
+    nPassBVeto += 1;
 
+
+    beforeTMass.Fill( itau, TauP4, iLep, eventWeight );
     //Reject W+Jets
     float LepMetTranverseMass;
     if(doMuon){
@@ -203,9 +209,6 @@ int main(int argc, char** argv) {
     passTau.Fill(eventWeight);
 
 
-    //ttbar veto with bjet veto
-    if(GetBJets()) { continue; }
-    nPassBVeto += 1;
 
 
     // Construct the visible mu+tau system
@@ -217,6 +220,7 @@ int main(int argc, char** argv) {
 
   //end of analysis code, close and write histograms/file
   fout->cd();
+  beforeTMass.Write();
   basicselection.Write();
   noCut         .Write();
   passTrigger   .Write();

--- a/plotDump.py
+++ b/plotDump.py
@@ -47,7 +47,7 @@ varLabels = {"LepEta": flavor+" #eta",
 
 QCD_SS_to_OS_SF = 1.0
 
-for sel in ["BasicSelection"]:
+for sel in ["BasicSelection","BeforeTMass"]:
     for iso in ["Iso","antiIso"]:
         for var, label in varLabels.items():
             samples=collections.OrderedDict()

--- a/ratio_calc.py
+++ b/ratio_calc.py
@@ -1,0 +1,88 @@
+# Code written by:  zaixing.mao@cern.ch && edward.laird@cern.ch from Brown U.
+#!/usr/bin/env python
+import ROOT as r
+import numpy
+from sys import argv, exit, stdout, stderr
+import math
+
+dirName = argv[1]
+
+
+r.gStyle.SetOptStat(0)
+r.gROOT.SetBatch(True)  # to suppress canvas pop-outs
+
+
+f = r.TFile("prefit.root","recreate")
+
+def getBins(hist, mass_low, mass_high):
+    bin_low = -1
+    bin_high = -1
+    for i in range(hist.GetNbinsX()):
+        if hist.GetBinCenter(i+1) >= mass_low and bin_low == -1:
+            bin_low = i+1
+        if hist.GetBinCenter(i+1) >= mass_high and bin_high == -1:
+            bin_high = i
+        if bin_low != -1 and bin_high != -1:
+            return bin_low, bin_high
+    return bin_low, bin_high
+
+
+def ratio_calculator(fileList = [], mass_low = 25, mass_high = 125, nbins = 50, variableName = "visibleMass", binsSetting = [30, 0, 150]):
+
+   
+    IsoOrAnti = ["Iso_","antiIso_"]
+    WJets_MC_IA = 0.0 
+    WJets_Data_IA = 0.0
+
+    #loop over all the samples
+    for iFileName, iFileLocation in fileList:
+        isData = False
+        if iFileName == 'data':
+            isData = True
+        isWJet = False
+        if iFileName == 'WJets':
+            isWJet = True
+
+        print iFileName
+
+        ifile = r.TFile(iFileLocation)
+
+        weight = -1.0
+        tauWeight = 0.9
+        
+        if isData or isWJet:
+            weight = 1.0
+            tauWeight = 1.0
+
+        for i,iA in enumerate(IsoOrAnti):
+           osName = "%sOS" %(variableName+iA)
+           ssName = "%sSS" %(variableName+iA)
+
+           lowBin, highBin = getBins(ifile.Get(osName), mass_low, mass_high)
+
+           if isWJet:
+               WJets_MC_IA += weight*ifile.Get(osName).Integral(lowBin, highBin)
+           else:
+               WJets_Data_IA += weight*ifile.Get(osName).Integral(lowBin, highBin)
+     
+    
+    ratio = WJets_Data_IA / WJets_MC_IA
+    print("WJet_Data to WJet_MC ratio: "+str(ratio))
+    
+
+   
+
+   
+
+fileList = [('DY', '%s/DYJetsToTauTau.root' %dirName),
+            ('ZLL', '%s/DYJetsToLL.root ' %dirName),
+            ('TTJets', '%s/TTJets.root' %dirName),
+            ('WJets', '%s/WJetsToLNu.root' %dirName),
+#            ('Diboson', '%s/WZ.root' %dirName),
+#            ('Diboson', '%s/ZZ.root' %dirName),
+            ('data', '%s/data.root' %dirName),
+            ]
+
+variableName = "BeforeTMass_LepTMass_"
+bining = []
+ratio_calculator(fileList, 80, 160, 30, variableName, [30, 0, 300])


### PR DESCRIPTION
Made HistogramMgr.h look at higher bins for the now uncut LepTMass histogram; changed cut flow and added EventHisto beforeTMass (makes histograms before <40GeV jet cut) on ZTT_XSection.cc;  added this to plotDump.py; and added ratio_calc.py to calculate the WJet ratios.